### PR TITLE
Allow invocation without POM config.

### DIFF
--- a/animal-sniffer-enforcer-rule/src/main/java/org/codehaus/mojo/animal_sniffer/enforcer/CheckSignatureRule.java
+++ b/animal-sniffer-enforcer-rule/src/main/java/org/codehaus/mojo/animal_sniffer/enforcer/CheckSignatureRule.java
@@ -81,7 +81,7 @@ public class CheckSignatureRule
 
     /**
      * Annotation names to consider to ignore annotated methods, classes or fields.
-     * <p/>
+     * <p>
      * By default {@value SignatureChecker#ANNOTATION_FQN} and
      * {@value SignatureChecker#PREVIOUS_ANNOTATION_FQN} are used.
      *

--- a/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/CheckSignatureMojo.java
+++ b/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/CheckSignatureMojo.java
@@ -75,8 +75,25 @@ public class CheckSignatureMojo
     /**
      * Signature module to use.
      */
-    @Parameter( required = true )
+    @Parameter( required = true, property="animal.sniffer.signature" )
     protected Signature signature;
+
+	/**
+	 * @param signatureId
+	 *            A fully-qualified path to a signature jar. This allows users
+	 *            to set a signature for command-line invocations, such as:
+	 *            <p>
+	 *            <code>mvn org.codehaus.mojo:animal-sniffer-maven-plugin:1.15:check -Dsignature=org.codehaus.mojo.signature:java17:1.0</code>
+	 */
+    public void setSignature( String signatureId ) {
+		String[] signatureParts = signatureId.split(":");
+		if(signatureParts.length == 3) {
+			this.signature = new Signature();
+			this.signature.setGroupId(signatureParts[0]);
+			this.signature.setArtifactId(signatureParts[1]);
+			this.signature.setVersion(signatureParts[2]);
+		}
+    }
 
     /**
      * Class names to ignore signatures for (wildcards accepted).
@@ -87,7 +104,7 @@ public class CheckSignatureMojo
 
     /**
      * Annotation names to consider to ignore annotated methods, classes or fields.
-     * <p/>
+     * <p>
      * By default 'org.codehaus.mojo.animal_sniffer.IgnoreJRERequirement' and
      * 'org.jvnet.animal_sniffer.IgnoreJRERequirement' are used.
      *
@@ -171,6 +188,12 @@ public class CheckSignatureMojo
             getLog().info( "Signature checking is skipped." );
             return;
         }
+
+		if ( signature == null || StringUtils.isBlank(signature.getGroupId()) || signature.getGroupId() == "null") {
+			getLog().info( "Signature version is: " + signature.getVersion() );
+			return;
+        }
+
 
         try
         {

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureChecker.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureChecker.java
@@ -165,10 +165,10 @@ public class SignatureChecker
     /**
      * Sets the annotation type(s) that this checker should consider to ignore annotated
      * methods, classes or fields.
-     * <p/>
+     * <p>
      * By default, the {@link #ANNOTATION_FQN} and {@link #PREVIOUS_ANNOTATION_FQN} are
      * used.
-     * <p/>
+     * <p>
      * If you want to <strong>add</strong> an extra annotation types, make sure to add
      * the standard one to the specified lists.
      *


### PR DESCRIPTION
This change allows the user to specify the fully-qualified Maven artifact path for an API signature packages on the command line.  This allows for configuration-less invocation of the plugin like this:

```bash
mvn org.codehaus.mojo:animal-sniffer-maven-plugin:1.15-SNAPSHOT:check -Danimal.sniffer.signature=org.codehaus.mojo.signature:java16:1.0
```

This is especially useful when wrangling in API restriction checks even if they aren't configured in the POM.  This can be used as a post-job step in Jenkins, for example.