### PR TITLE
Changed Animal Sniffer to work with Maven 3.3.x (also 3.2.5)

### DIFF
--- a/animal-sniffer-maven-plugin/pom.xml
+++ b/animal-sniffer-maven-plugin/pom.xml
@@ -62,27 +62,22 @@
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-plugin-api</artifactId>
-      <version>2.0.1</version>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-core</artifactId>
-      <version>2.0.1</version>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-project</artifactId>
-      <version>2.0.1</version>
+      <version>3.0-alpha-1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven</groupId>
       <artifactId>maven-artifact</artifactId>
-      <version>2.0.1</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-toolchain</artifactId>
-      <version>2.2.1</version>
+      <version>3.3.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.maven.shared</groupId>

--- a/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/BuildSignaturesMojo.java
+++ b/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/BuildSignaturesMojo.java
@@ -44,7 +44,7 @@ import org.apache.maven.toolchain.Toolchain;
 import org.apache.maven.toolchain.ToolchainManager;
 import org.apache.maven.toolchain.ToolchainManagerPrivate;
 import org.apache.maven.toolchain.ToolchainPrivate;
-import org.apache.maven.toolchain.java.JavaToolChain;
+import org.apache.maven.toolchain.java.JavaToolchain;
 import org.codehaus.mojo.animal_sniffer.SignatureBuilder;
 import org.codehaus.plexus.util.StringUtils;
 import org.codehaus.plexus.util.cli.CommandLineException;
@@ -318,7 +318,7 @@ public class BuildSignaturesMojo
                         return;
                     }
                 }
-                else if ( tc != null && tc instanceof JavaToolChain )
+                else if ( tc != null && tc instanceof JavaToolchain )
                 {
                     getLog().info( "Toolchain in animal-sniffer-maven-plugin: " + tc );
 

--- a/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/JdkToolchainConverter.java
+++ b/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/JdkToolchainConverter.java
@@ -74,16 +74,9 @@ public class JdkToolchainConverter
         Map parameters = new HashMap();
         for ( int j = 0; j < params.length; j++ )
         {
-            try
-            {
-                String name = params[j].getName();
-                String val = params[j].getValue();
-                parameters.put( name, val );
-            }
-            catch ( PlexusConfigurationException ex )
-            {
-                throw new ComponentConfigurationException( ex );
-            }
+            String name = params[j].getName();
+            String val = params[j].getValue();
+            parameters.put( name, val );
         }
         final JdkToolchain result = new JdkToolchain();
         result.setParameters( Collections.unmodifiableMap( parameters ) );


### PR DESCRIPTION
The change in the branch `bug-fix/maven-3.3` is a fix to make the `animal-sniffer-maven-plugin` compatible with Maven 3.3.x. There was a change from Maven 3.2.3 to 3.2.5 which made the plugin not working anymore  (see [MNG-5719](https://issues.apache.org/jira/browse/MNG-5719)). Fixed this.

Tested the changes with Maven 3.2.5, 3.3.1 and 3.3.3 with the goal `build` (which did not work anymore).

Changes made:
* Changed dependencies in pom to maven to 3.3.1.
* Changed `JdkToolchainConverter.java`  because the exception is not thrown anymore.
* Changed `BuildSignaturesMojo.java` because the class `org.apache.maven.toolchain.java.JavaToolChain` is renamed to `org.apache.maven.toolchain.java.JavaToolchain`.