### PR TITLE
Changed Animal Sniffer to recognize included and excluded classes correctly.

### DIFF
--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureBuilder.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureBuilder.java
@@ -150,7 +150,7 @@ public class SignatureBuilder
                 boolean included = false;
                 for( Pattern p : includeClasses )
                 {
-                    included = p.matcher( className ).matches();
+                    included |= p.matcher( className ).matches();
                 }
                 if ( !included )
                 {
@@ -162,7 +162,7 @@ public class SignatureBuilder
                 boolean excluded = false;
                 for( Pattern p : excludeClasses )
                 {
-                    excluded = p.matcher( className ).matches();
+                    excluded |= p.matcher( className ).matches();
                 }
                 if ( excluded )
                 {


### PR DESCRIPTION
Animal Sniffer 1.14 introduced a regression. The including and excluding of classes in the configuration does not work correctly (it works correctly with 1.13).

The error is introduced in class `SignatureBuilder` while processing the inclusions and exclusions. Only the last inclusion and exclusion are taken into account.

As an example:
When scanning the JDK 1.8 with the inclusion
```
              <includeClasses>
                <includeClass>java.*</includeClass>
                <includeClass>javax.*</includeClass>
                <includeClass>org.ietf.jgss.*</includeClass>
                <includeClass>org.omg.*</includeClass>
                <includeClass>org.w3c.dom.*</includeClass>
                <includeClass>org.xml.sax.*</includeClass>
              </includeClasses>

```
leads to a class count of 45 classes.

With the proposed change the plugin recognizes 8040 classes.