### PR TITLE
Avoid NPE in SignatureChecker$CheckingVisitor.find

### DIFF
--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureChecker.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureChecker.java
@@ -499,7 +499,7 @@ public class SignatureChecker
 
                     Clazz returnClass = classes.get( returnType );
 
-                    if ( returnClass.getSuperClass() != null )
+                    if ( returnClass != null && returnClass.getSuperClass() != null )
                     {
                         String oldSignature = method + 'L' + returnClass.getSuperClass() + ';';
                         if ( find( c, oldSignature, false ) )


### PR DESCRIPTION
The return type may not exist in the known classes map.

Fixes #8