### PR TITLE
Handle multirelease JARs

### DIFF
--- a/animal-sniffer-maven-plugin/src/it/issue-32-module-info/pom.xml
+++ b/animal-sniffer-maven-plugin/src/it/issue-32-module-info/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The MIT License
+
+  Copyright (c) 2017 codehaus.org, jglick@cloudbees.com.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>real-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Issue #32 module info</name>
+
+  <description>
+    Tests that module-info.class is ignored (pending real support).
+  </description>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.0.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${pluginGroupId}</groupId>
+        <artifactId>${pluginArtifactId}</artifactId>
+        <version>${pluginVersion}</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <signature>
+                <groupId>org.codehaus.mojo.signature</groupId>
+                <artifactId>java14</artifactId>
+                <version>1.0</version>
+              </signature>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.codehaus.groovy</groupId>
+      <artifactId>groovy</artifactId>
+      <version>2.5.0-beta-1</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <pluginGroupId>@project.groupId@</pluginGroupId>
+    <pluginArtifactId>@project.artifactId@</pluginArtifactId>
+    <pluginVersion>@project.version@</pluginVersion>
+  </properties>
+
+</project>

--- a/animal-sniffer-maven-plugin/src/it/issue-32-module-info/src/main/java/test/Main.java
+++ b/animal-sniffer-maven-plugin/src/it/issue-32-module-info/src/main/java/test/Main.java
@@ -1,0 +1,33 @@
+package test;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009, codehaus.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+    }
+}

--- a/animal-sniffer-maven-plugin/src/it/issue-32-multirelease/pom.xml
+++ b/animal-sniffer-maven-plugin/src/it/issue-32-multirelease/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The MIT License
+
+  Copyright (c) 2017 codehaus.org, jglick@cloudbees.com.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>real-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Issue #32 multirelease</name>
+
+  <description>
+    Tests that multirelease JARs pass.
+  </description>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <version>2.0.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>1.5</source>
+          <target>1.5</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>${pluginGroupId}</groupId>
+        <artifactId>${pluginArtifactId}</artifactId>
+        <version>${pluginVersion}</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <signature>
+                <groupId>org.codehaus.mojo.signature</groupId>
+                <artifactId>java14</artifactId>
+                <version>1.0</version>
+              </signature>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+  <dependencies>
+    <dependency>
+      <groupId>org.jboss.marshalling</groupId>
+      <artifactId>jboss-marshalling-river</artifactId>
+      <version>2.0.0.CR1</version>
+    </dependency>
+  </dependencies>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <pluginGroupId>@project.groupId@</pluginGroupId>
+    <pluginArtifactId>@project.artifactId@</pluginArtifactId>
+    <pluginVersion>@project.version@</pluginVersion>
+  </properties>
+
+</project>

--- a/animal-sniffer-maven-plugin/src/it/issue-32-multirelease/src/main/java/test/Main.java
+++ b/animal-sniffer-maven-plugin/src/it/issue-32-multirelease/src/main/java/test/Main.java
@@ -1,0 +1,33 @@
+package test;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009, codehaus.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+    }
+}

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
@@ -139,7 +139,7 @@ public abstract class ClassFileVisitor
             {
                 JarEntry x = e.nextElement();
                 String name = x.getName();
-                if ( !name.endsWith( ".class" ) || name.startsWith("META-INF/") )
+                if ( !name.endsWith( ".class" ) || name.startsWith( "META-INF/" ) || name.equals( "module-info.class" ) )
                 {
                     continue;
                 }

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
@@ -138,7 +138,8 @@ public abstract class ClassFileVisitor
             while ( e.hasMoreElements() )
             {
                 JarEntry x = e.nextElement();
-                if ( !x.getName().endsWith( ".class" ) )
+                String name = x.getName();
+                if ( !name.endsWith( ".class" ) || name.startsWith("META-INF/") )
                 {
                     continue;
                 }

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
@@ -37,12 +37,27 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+import org.codehaus.mojo.animal_sniffer.logging.Logger;
+import org.codehaus.mojo.animal_sniffer.logging.PrintWriterLogger;
 
 /**
  * @author Kohsuke Kawaguchi
  */
 public abstract class ClassFileVisitor
 {
+
+    protected final Logger logger;
+
+    protected ClassFileVisitor()
+    {
+        this( new PrintWriterLogger( System.err ) );
+    }
+
+    protected ClassFileVisitor( Logger logger )
+    {
+        this.logger = logger;
+    }
+
     /**
      * Whether to check inside <code>.jar</code> files
      */
@@ -139,8 +154,13 @@ public abstract class ClassFileVisitor
             {
                 JarEntry x = e.nextElement();
                 String name = x.getName();
-                if ( !name.endsWith( ".class" ) || name.startsWith( "META-INF/" ) || name.equals( "module-info.class" ) )
+                if ( !name.endsWith( ".class" ) )
                 {
+                    continue; // uninteresting to log even at debug
+                }
+                if ( name.startsWith( "META-INF/" ) || name.equals( "module-info.class" ) )
+                {
+                    logger.debug( "Ignoring " + name );
                     continue;
                 }
                 entries.add( x );
@@ -148,6 +168,7 @@ public abstract class ClassFileVisitor
             Iterator<JarEntry> it = entries.iterator();
             while ( it.hasNext() ) {
                 JarEntry x = it.next();
+                // Even debug level seems too verbose for: logger.debug( "Processing " + x.getName() + " in " + file );
                 InputStream is = jar.getInputStream( x );
                 try
                 {

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassListBuilder.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassListBuilder.java
@@ -45,8 +45,6 @@ public class ClassListBuilder
 {
     private final Set<String> packages;
 
-    private final Logger logger;
-
     public Set<String> getPackages()
     {
         return packages;
@@ -54,8 +52,8 @@ public class ClassListBuilder
 
     public ClassListBuilder( Set<String> packages, Logger logger )
     {
+        super( logger );
         this.packages = packages;
-        this.logger = logger;
     }
 
     public ClassListBuilder( Logger logger )

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassListBuilder.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassListBuilder.java
@@ -87,5 +87,12 @@ public class ClassListBuilder
             ioException.initCause( e );
             throw ioException;
         }
+        catch ( IllegalArgumentException e )
+        {
+            logger.error( "Bad class file " + name );
+            IOException ioException = new IOException( "Bad class file " + name );
+            ioException.initCause( e );
+            throw ioException;
+        }
     }
 }


### PR DESCRIPTION
Currently if you try to run Animal Sniffer on a project with a dependency on a multirelease JAR containing JDK 9 class files, such as is produced by https://github.com/jboss-remoting/jboss-marshalling/pull/50, you just get an `IllegalArgumentException` with no explanation (not even the name of the JAR or class file causing the problem).

This patch ignores the class files intended for other Java versions. A more sophisticated approach would perhaps be to allow you to select multiple signatures and then check each component of the multirelease JAR accordingly, but this at least unblocks you and allows the plugin to be used. (Configuring `ignores` on the mojo does not help because the IAE is thrown before that parameter is even processed!)

Could try to add an IT upon request, but #25 has been left unmerged even with one so I am not going to bother until I know it will be accepted.

@reviewbybees for my colleagues