### PR TITLE
[FIXED #33] allow config to not fail the build on violations

### DIFF
--- a/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/CheckSignatureMojo.java
+++ b/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/CheckSignatureMojo.java
@@ -161,6 +161,13 @@ public class CheckSignatureMojo
     protected boolean skip;
 
     /**
+     * Should signature check failures throw an error?
+     *
+     */
+    @Parameter( defaultValue = "true", property = "animal.sniffer.failOnError" )
+    protected boolean failOnError;
+
+    /**
      */
     @Component
     protected ArtifactResolver resolver;
@@ -262,8 +269,16 @@ public class CheckSignatureMojo
 
             if ( signatureChecker.isSignatureBroken() )
             {
-                throw new MojoFailureException(
-                    "Signature errors found. Verify them and ignore them with the proper annotation if needed." );
+	        if (failOnError)
+		{
+                    throw new MojoFailureException(
+                        "Signature errors found. Verify them and ignore them with the proper annotation if needed." );
+	        }
+		else
+		{
+		    getLog().info(
+		        "Signature errors found. Verify them and ignore them with the proper annotation if needed." );
+		}
             }
         }
         catch ( IOException e )


### PR DESCRIPTION
Allows a new configuration property 'error' which is true by default to maintain current behavior. The new property lets users not fail the build if errors are found, but simply to allow the error messages to be shown.