### PR TITLE
Captures the jar name when any Exception occurs

### DIFF
--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
@@ -164,6 +164,13 @@ public abstract class ClassFileVisitor
             e.initCause( cause );
             throw e;
         }
+        catch( Exception cause )
+        {
+            IOException e = new IOException( " exception while processing jar " + file.getPath() + " : " + cause.getMessage() );
+            e.initCause( cause );
+            throw e;
+        }
+
 
     }
 


### PR DESCRIPTION
...in ClassFileVisitor.processJarFile(), in the same style as is done
for IOException in the current source.

This handles cases like getting:

  java.lang.SecurityException: Invalid signature file digest for Manifest main attribute

from some signed jar.  The change will inject an IOException
encapsulating the original Exception, so a message like the following
will show up in stack traces (in addition to the above original cause):

  java.io.IOException:  exception while processing jar /path/to/the-offending.jar: Invalid signature file digest for Manifest main attributes