### PR TITLE
Update to ASM 5.2

### DIFF
--- a/animal-sniffer/pom.xml
+++ b/animal-sniffer/pom.xml
@@ -47,7 +47,7 @@
     <dependency>
       <groupId>org.ow2.asm</groupId>
       <artifactId>asm-all</artifactId>
-      <version>5.0.3</version>
+      <version>5.2</version>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
animal-sniffer is currently using ASM 5.0.2; it should be updated to 5.2. Here's the changelog: http://asm.ow2.org/history.html