### PR TITLE
Broken IT

### DIFF
--- a/animal-sniffer-maven-plugin/src/it/jdk14-with-sig14-from-cli/invoker.properties
+++ b/animal-sniffer-maven-plugin/src/it/jdk14-with-sig14-from-cli/invoker.properties
@@ -1,1 +1,1 @@
-invoker.goals=org.codehaus.mojo:animal-sniffer-maven-plugin:1.15-SNAPSHOT:check -Danimal.sniffer.signature=org.codehaus.mojo.signature:java14:1.0
+invoker.goals=verify -Danimal.sniffer.signature=org.codehaus.mojo.signature:java14:1.0

--- a/animal-sniffer-maven-plugin/src/it/jdk14-with-sig14-from-cli/pom.xml
+++ b/animal-sniffer-maven-plugin/src/it/jdk14-with-sig14-from-cli/pom.xml
@@ -92,13 +92,6 @@
             <goals>
               <goal>check</goal>
             </goals>
-            <configuration>
-              <signature>
-                <groupId>org.codehaus.mojo.signature</groupId>
-                <artifactId>java14</artifactId>
-                <version>1.0</version>
-              </signature>
-            </configuration>
           </execution>
         </executions>
       </plugin>


### PR DESCRIPTION
@olamy’s IT has been failing, causing every recent PR to be marked as a failure as well. This seems to fix it, at least on Maven 3.5.0.

@reviewbybees for my colleagues