### PR TITLE
Fix ClassFileVisitor resource leak

### DIFF
--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
@@ -137,9 +137,8 @@ public abstract class ClassFileVisitor
     protected void processJarFile( File file )
         throws IOException
     {
-        try
+        try ( JarFile jar = new JarFile( file ) )
         {
-            JarFile jar = new JarFile( file );
             SortedSet<JarEntry> entries = new TreeSet<JarEntry>( new Comparator<JarEntry>() {
                 public int compare( JarEntry e1, JarEntry e2 )
                 {


### PR DESCRIPTION
The java.util.jar.JarFile is not closed after usage. Because this class is based on java.util.zip.ZipFile it should be closed to release the file handles.