### PR TITLE
Artifact.getFile can be NULL when dependencies haven't been completel…

### DIFF
--- a/animal-sniffer-enforcer-rule/src/main/java/org/codehaus/mojo/animal_sniffer/enforcer/CheckSignatureRule.java
+++ b/animal-sniffer-enforcer-rule/src/main/java/org/codehaus/mojo/animal_sniffer/enforcer/CheckSignatureRule.java
@@ -330,6 +330,13 @@ public class CheckSignatureRule
                     continue;
                 }
 
+                if ( artifact.getFile() == null )
+                {
+                    logger.warn( "Skipping classes in artifact " + artifactId( artifact )
+                                        + " as there are unresolved dependencies." );
+                    continue;
+                }
+
                 logger.debug( "Adding classes in artifact " + artifactId( artifact ) +
                                     " to the ignores" );
                 v.process( artifact.getFile() );


### PR DESCRIPTION
…y resolved.

My colleague ran into the same issue with Eclipse as described in the linked issue..

```
Execution check-java-compat of goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce failed. (org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce:check-java-compat:process-classes)

org.apache.maven.plugin.PluginExecutionException: Execution check-java-compat of goal org.apache.maven.plugins:maven-enforcer-plugin:3.0.0-M2:enforce failed.
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:145)
    at org.eclipse.m2e.core.internal.embedder.MavenImpl.execute(MavenImpl.java:331)
    at org.eclipse.m2e.core.internal.embedder.MavenImpl$11.call(MavenImpl.java:1362)
    at org.eclipse.m2e.core.internal.embedder.MavenImpl$11.call(MavenImpl.java:1)
    at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:176)
    at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:112)
    at org.eclipse.m2e.core.internal.embedder.MavenImpl.execute(MavenImpl.java:1360)
    at org.eclipse.m2e.core.project.configurator.MojoExecutionBuildParticipant.build(MojoExecutionBuildParticipant.java:52)
    at org.eclipse.m2e.core.internal.builder.MavenBuilderImpl.build(MavenBuilderImpl.java:137)
    at org.eclipse.m2e.core.internal.builder.MavenBuilder$1.method(MavenBuilder.java:172)
    at org.eclipse.m2e.core.internal.builder.MavenBuilder$1.method(MavenBuilder.java:1)
    at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod$1$1.call(MavenBuilder.java:115)
    at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:176)
    at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:112)
    at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod$1.call(MavenBuilder.java:105)
    at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.executeBare(MavenExecutionContext.java:176)
    at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:151)
    at org.eclipse.m2e.core.internal.embedder.MavenExecutionContext.execute(MavenExecutionContext.java:99)
    at org.eclipse.m2e.core.internal.builder.MavenBuilder$BuildMethod.execute(MavenBuilder.java:86)
    at org.eclipse.m2e.core.internal.builder.MavenBuilder.build(MavenBuilder.java:200)
    at org.eclipse.core.internal.events.BuildManager$2.run(BuildManager.java:735)
    at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
    at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:206)
    at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:246)
    at org.eclipse.core.internal.events.BuildManager$1.run(BuildManager.java:301)
    at org.eclipse.core.runtime.SafeRunner.run(SafeRunner.java:42)
    at org.eclipse.core.internal.events.BuildManager.basicBuild(BuildManager.java:304)
    at org.eclipse.core.internal.events.BuildManager.basicBuildLoop(BuildManager.java:360)
    at org.eclipse.core.internal.events.BuildManager.build(BuildManager.java:383)
    at org.eclipse.core.internal.resources.Workspace.buildInternal(Workspace.java:487)
    at org.eclipse.core.internal.resources.Workspace.build(Workspace.java:399)
    at org.eclipse.ui.actions.GlobalBuildAction$1.run(GlobalBuildAction.java:177)
    at org.eclipse.core.internal.jobs.Worker.run(Worker.java:55)
Caused by: java.lang.NullPointerException
    at org.codehaus.mojo.animal_sniffer.ClassFileVisitor.process(ClassFileVisitor.java:110)
    at org.codehaus.mojo.animal_sniffer.enforcer.CheckSignatureRule.apply(CheckSignatureRule.java:335)
    at org.codehaus.mojo.animal_sniffer.enforcer.CheckSignatureRule.buildPackageList(CheckSignatureRule.java:282)
    at org.codehaus.mojo.animal_sniffer.enforcer.CheckSignatureRule.execute(CheckSignatureRule.java:178)
    at org.apache.maven.plugins.enforcer.EnforceMojo.execute(EnforceMojo.java:194)
    at org.apache.maven.plugin.DefaultBuildPluginManager.executeMojo(DefaultBuildPluginManager.java:134)
    ... 32 more
```

Fixes https://github.com/mojohaus/animal-sniffer/issues/20