### PR TITLE
Capture signatures from JDK9/10 JMOD files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - oraclejdk10
+  - openjdk10
 dist: trusty
 install:
   - "mvn -N io.takari:maven:0.6.1:wrapper -Dmaven=${MAVEN_VERSION}"

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassFileVisitor.java
@@ -115,7 +115,7 @@ public abstract class ClassFileVisitor
         {
             processClassFile( file );
         }
-        else if ( file.getName().endsWith( ".jar" ) && checkJars )
+        else if ( ( file.getName().endsWith( ".jar" ) || file.getName().endsWith( ".jmod" ) ) && checkJars )
         {
             processJarFile( file );
         }

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/Clazz.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/Clazz.java
@@ -28,6 +28,7 @@ package org.codehaus.mojo.animal_sniffer;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -83,12 +84,12 @@ public final class Clazz
      */
     public Clazz( Clazz defA, Clazz defB )
     {
-        if ( !defA.name.equals( defB.name ) )
+        if ( !Objects.equals(defA.name, defB.name ) )
         {
             // nothing we can do... this is an invalid argument
             throw new ClassCastException( "Cannot merge different classes: " + defA.name + " and " + defB.name );
         }
-        if ( !defA.superClass.equals( defB.superClass ) )
+        if ( !Objects.equals(defA.superClass, defB.superClass ) )
         {
             // nothing we can do... this is a breaking change
             throw new ClassCastException( "Cannot merger class " + defB.name + " as it has changed superclass:" );

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureBuilder.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureBuilder.java
@@ -199,8 +199,9 @@ public class SignatureBuilder
     {
         private Clazz clazz;
 
+        @SuppressWarnings("deprecation")
         public SignatureVisitor() {
-            super(Opcodes.ASM5);
+            super(Opcodes.ASM7_EXPERIMENTAL);
         }
 
         public void visit( int version, int access, String name, String signature, String superName,

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureBuilder.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureBuilder.java
@@ -201,7 +201,7 @@ public class SignatureBuilder
 
         @SuppressWarnings("deprecation")
         public SignatureVisitor() {
-            super(Opcodes.ASM7_EXPERIMENTAL);
+            super(Opcodes.ASM7);
         }
 
         public void visit( int version, int access, String name, String signature, String superName,

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>6.2.1</version>
+        <version>7.0</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -201,7 +201,7 @@
       <dependency>
         <groupId>org.ow2.asm</groupId>
         <artifactId>asm</artifactId>
-        <version>6.2</version>
+        <version>6.2.1</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
This PR allows to capture signatures of JMOD files with latest version of ASM. Tested with Oracle JDK 10.0.2.

ASM Changelog: https://asm.ow2.io/versions.html

    5 August 2018: ASM 6.2.1 (tag ASM_6_2_1)

    small improvements
        !177: Ensure instructions belong only to one list
        !178: Allow setting stack values in analysis frames
        !179: Multiple methods for initializing analysis values
        !181: Improve exception messages when exceeding classfile limits
        !182: Minor Javadoc improvements
    bug fixes
        317609: Enhance ClassWriter to take a class loader for use with getCommonSuperClass
        317833: When ClassWriter copies constant pool of class reader, ClassWriter.COMPUTE_MAX does not consider changes in argument sizes
        317835: COMPUTE_MAX_STACK_AND_LOCAL_FROM_FRAMES does not handle LONG and DOUBLE types correctly
        317837: Apparent regression in GeneratorAdapter.java `cast` function
        317843: Bug in CheckMethodAdapter