### PR TITLE
Switch from openjdk10 to oraclejdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ env:
 jdk:
   - oraclejdk8
   - oraclejdk9
-  - openjdk10
+  - oraclejdk11
 dist: trusty
 install:
   - "mvn -N io.takari:maven:0.6.1:wrapper -Dmaven=${MAVEN_VERSION}"


### PR DESCRIPTION
Travis has removed OpenJDK10 as it reached end of life Oct 2018