### PR TITLE
Fix #5: check test classes

### DIFF
--- a/animal-sniffer-enforcer-rule/src/site/apt/examples/checking-signatures.apt.vm
+++ b/animal-sniffer-enforcer-rule/src/site/apt/examples/checking-signatures.apt.vm
@@ -61,7 +61,7 @@ Checking a project against API signatures
            ....
           <execution>
             <id>check-signatures</id>
-            <phase>test</phase>
+            <phase>process-test-classes</phase>
             <goals>
               <goal>enforce</goal>
             </goals>
@@ -158,7 +158,7 @@ public final class MapFactory {
            ....
           <execution>
             <id>check-signatures</id>
-            <phase>test</phase>
+            <phase>process-test-classes</phase>
             <goals>
               <goal>enforce</goal>
             </goals>
@@ -217,7 +217,7 @@ public final class MapFactory {
            ....
           <execution>
             <id>check-signatures</id>
-            <phase>test</phase>
+            <phase>process-test-classes</phase>
             <goals>
               <goal>enforce</goal>
             </goals>
@@ -359,7 +359,7 @@ public final class Someclass {
            ....
           <execution>
             <id>check-signatures</id>
-            <phase>test</phase>
+            <phase>process-test-classes</phase>
             <goals>
               <goal>enforce</goal>
             </goals>

--- a/animal-sniffer-enforcer-rule/src/site/apt/usage.apt.vm
+++ b/animal-sniffer-enforcer-rule/src/site/apt/usage.apt.vm
@@ -65,7 +65,7 @@ Usage
            ....
           <execution>
             <id>check-signatures</id>
-            <phase>test</phase>
+            <phase>process-test-classes</phase>
             <goals>
               <goal>enforce</goal>
             </goals>

--- a/animal-sniffer-maven-plugin/src/it/github-5-test-classes/invoker.properties
+++ b/animal-sniffer-maven-plugin/src/it/github-5-test-classes/invoker.properties
@@ -1,0 +1,27 @@
+#
+# The MIT License
+#
+# Copyright (c) 2009 codehaus.org.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+invoker.goals.1=verify -Danimal.sniffer.checkTestClasses=false
+
+invoker.goals.2=verify
+invoker.buildResult.2=failure

--- a/animal-sniffer-maven-plugin/src/it/github-5-test-classes/pom.xml
+++ b/animal-sniffer-maven-plugin/src/it/github-5-test-classes/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  The MIT License
+
+  Copyright (c) 2009 codehaus.org.
+
+  Permission is hereby granted, free of charge, to any person obtaining a copy
+  of this software and associated documentation files (the "Software"), to deal
+  in the Software without restriction, including without limitation the rights
+  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+  copies of the Software, and to permit persons to whom the Software is
+  furnished to do so, subject to the following conditions:
+
+  The above copyright notice and this permission notice shall be included in
+  all copies or substantial portions of the Software.
+
+  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+  THE SOFTWARE.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>localdomain.localhost</groupId>
+  <artifactId>test-classes-test</artifactId>
+  <version>1.0-SNAPSHOT</version>
+  <packaging>jar</packaging>
+
+  <name>Real Test</name>
+
+  <description>
+    Tests that verifies that test classes are checked.
+  </description>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <artifactId>maven-compiler-plugin</artifactId>
+          <configuration>
+            <source>@mojo.java.target@</source>
+            <target>@mojo.java.target@</target>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>${pluginGroupId}</groupId>
+        <artifactId>${pluginArtifactId}</artifactId>
+        <version>${pluginVersion}</version>
+        <executions>
+          <execution>
+            <phase>test</phase>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <configuration>
+              <signature>
+                <groupId>org.codehaus.mojo.signature</groupId>
+                <artifactId>java14</artifactId>
+                <version>1.0</version>
+              </signature>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
+  <properties>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <project.build.outputEncoding>UTF-8</project.build.outputEncoding>
+    <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    <pluginGroupId>@project.groupId@</pluginGroupId>
+    <pluginArtifactId>@project.artifactId@</pluginArtifactId>
+    <pluginVersion>@project.version@</pluginVersion>
+  </properties>
+
+</project>

--- a/animal-sniffer-maven-plugin/src/it/github-5-test-classes/src/test/java/localhost/Main.java
+++ b/animal-sniffer-maven-plugin/src/it/github-5-test-classes/src/test/java/localhost/Main.java
@@ -1,0 +1,37 @@
+package localhost;
+
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2009, codehaus.org
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+public class Main
+{
+    public static void main( String[] args )
+    {
+        if ( new java.util.concurrent.ConcurrentHashMap().isEmpty() ) 
+        {
+            System.out.println( "All is good" );
+        }
+    }
+}

--- a/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/CheckSignatureMojo.java
+++ b/animal-sniffer-maven-plugin/src/main/java/org/codehaus/mojo/animal_sniffer/maven/CheckSignatureMojo.java
@@ -61,7 +61,7 @@ import java.util.Set;
  *
  * @author Kohsuke Kawaguchi
  */
-@Mojo( name = "check", defaultPhase = LifecyclePhase.PROCESS_CLASSES, requiresDependencyResolution = ResolutionScope.COMPILE, threadSafe = true )
+@Mojo( name = "check", defaultPhase = LifecyclePhase.PROCESS_TEST_CLASSES, requiresDependencyResolution = ResolutionScope.TEST, threadSafe = true )
 public class CheckSignatureMojo
     extends AbstractMojo
 {

--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-enforcer-plugin</artifactId>
-          <version>3.0.0-M2</version>
+          <version>3.0.0-M3</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Fixes #5.

Note: The first commit is fixing the following bogus error when running ` mvn clean verify -f animal-sniffer-maven-plugin/ -Prun-its`:
```
[INFO] --- maven-enforcer-plugin:3.0.0-M2:enforce (mojo-enforcer-rules) @ animal-sniffer-maven-plugin ---
[WARNING] Rule 2: org.apache.maven.plugins.enforcer.RequirePluginVersions failed with message:
Some plugins are missing valid versions:(LATEST RELEASE SNAPSHOT are not allowed )
org.apache.maven.plugins:maven-compiler-plugin.         The version currently in use is 3.8.0
org.apache.maven.plugins:maven-surefire-plugin.         The version currently in use is 2.22.0
org.apache.maven.plugins:maven-jar-plugin.      The version currently in use is 3.0.2
org.apache.maven.plugins:maven-clean-plugin.    The version currently in use is 3.0.0
org.apache.maven.plugins:maven-checkstyle-plugin.       The version currently in use is 2.16
org.apache.maven.plugins:maven-install-plugin.  The version currently in use is 2.5.2
org.apache.maven.plugins:maven-site-plugin.     The version currently in use is 3.7.1
org.apache.maven.plugins:maven-invoker-plugin.  The version currently in use is 3.2.1
org.apache.maven.plugins:maven-resources-plugin.        The version currently in use is 3.0.2
org.apache.maven.plugins:maven-deploy-plugin.   The version currently in use is 2.8.2
org.apache.maven.plugins:maven-enforcer-plugin.         The version currently in use is 3.0.0-M2
Best Practice is to always define plugin versions!
```