### PR TITLE
Remove incorrect handling of covariant return types

### DIFF
--- a/animal-sniffer-maven-plugin/src/it/manimalsniffer-49/invoker.properties
+++ b/animal-sniffer-maven-plugin/src/it/manimalsniffer-49/invoker.properties
@@ -1,4 +1,5 @@
 invoker.goals=verify
+invoker.buildResult=failure
 # this is where the method signature change happened
 invoker.java.version = 1.9+,!16
 

--- a/animal-sniffer-maven-plugin/src/it/manimalsniffer-49/verify.groovy
+++ b/animal-sniffer-maven-plugin/src/it/manimalsniffer-49/verify.groovy
@@ -1,4 +1,4 @@
 File log = new File(basedir, 'build.log')
 assert log.exists()
-assert log.text.contains( 'ManimalSniffer49.java:51: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.flip() has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.flip()' )
-assert log.text.contains( 'ManimalSniffer49.java:76: Covariant return type change detected: java.nio.Buffer java.nio.ByteBuffer.flip() has been changed to java.nio.ByteBuffer java.nio.ByteBuffer.flip()' )
+assert log.text.contains( 'ManimalSniffer49.java:51: Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.flip()' )
+assert log.text.contains( 'ManimalSniffer49.java:76: Undefined reference: java.nio.ByteBuffer java.nio.ByteBuffer.flip()' )

--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureChecker.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureChecker.java
@@ -38,14 +38,12 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.zip.GZIPInputStream;
 
 import org.codehaus.mojo.animal_sniffer.logging.Logger;
 import org.codehaus.mojo.animal_sniffer.logging.PrintWriterLogger;
 import org.objectweb.asm.AnnotationVisitor;
-import org.objectweb.asm.Attribute;
 import org.objectweb.asm.ClassReader;
 import org.objectweb.asm.ClassVisitor;
 import org.objectweb.asm.FieldVisitor;
@@ -516,7 +514,7 @@ public class SignatureChecker
             {
                 return;
             }
-            if ( find( classes.get( owner ), sig, true ) )
+            if ( find( classes.get( owner ), sig ) )
             {
                 return; // found it
             }
@@ -553,7 +551,7 @@ public class SignatureChecker
          * If the given signature is found in the specified class, return true.
          * @param baseFind TODO
          */
-        private boolean find( Clazz c , String sig , boolean baseFind  )
+        private boolean find( Clazz c , String sig )
         {
             if ( c == null )
             {
@@ -570,7 +568,7 @@ public class SignatureChecker
                 return false;
             }
 
-            if ( find( classes.get( c.getSuperClass() ), sig, false ) )
+            if ( find( classes.get( c.getSuperClass() ), sig ) )
             {
                 return true;
             }
@@ -579,41 +577,13 @@ public class SignatureChecker
             {
                 for ( int i = 0; i < c.getSuperInterfaces().length; i++ )
                 {
-                    if ( find( classes.get( c.getSuperInterfaces()[i] ), sig, false ) )
+                    if ( find( classes.get( c.getSuperInterfaces()[i] ), sig ) )
                     {
                         return true;
                     }
                 }
             }
 
-            // This is a rare case and quite expensive, so moving it to the end of this method and only execute it from
-            // first find-call.
-            if ( baseFind )
-            {
-                // MANIMALSNIFFER-49
-                Pattern returnTypePattern = Pattern.compile( "(.+\\))L(.+);" );
-                Matcher returnTypeMatcher = returnTypePattern.matcher( sig );
-                if ( returnTypeMatcher.matches() )
-                {
-                    String method = returnTypeMatcher.group( 1 );
-                    String returnType = returnTypeMatcher.group( 2 );
-
-                    Clazz returnClass = classes.get( returnType );
-
-                    if ( returnClass != null && returnClass.getSuperClass() != null )
-                    {
-                        String oldSignature = method + 'L' + returnClass.getSuperClass() + ';';
-                        if ( find( c, oldSignature, false ) )
-                        {
-                            logger.info( name + ( line > 0 ? ":" + line : "" )
-                                + ": Covariant return type change detected: "
-                                + toSourceForm( c.getName(), oldSignature ) + " has been changed to "
-                                + toSourceForm( c.getName(), sig ) );
-                            return true;
-                        }
-                    }
-                }
-            }
             return false;
         }
 


### PR DESCRIPTION
This removes incorrect covariant return type handling introduced in MANIMALSNIFFER-49. The ticket is no longer publicly accessible, so I lack the context of the original change.

The block of code removed in this PR prevented animalsniffer from catching covariant changes to return types which were compile-time compatible but not binary-compatible.

For example, if we take the code below

```
ByteBuffer buffer = ...
buffer.rewind();
```

and compile it on Java 8, we'll get bytecode which invokes

```
java.nio.ByteBuffer.rewind()Ljava/nio/Bufffer
```

If we compile it on Java 9+, while still targeting Java 8, we will get bytecode which invokes

```
java.nio.ByteBuffer.rewind()Ljava/nio/ByteBuffer
```

That's because this method with the more specific `ByteBuffer` return type is available in JDK9+.

Now, if we run the latter binary on Java 8, we will get a `NoSuchMethodError`. 

A recent example of this in the wild: https://github.com/grpc/grpc-java/pull/6839 (note that grpc-java uses animalnsniffer).