### PR TITLE
Treat covariant return type as an error

### DIFF
--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureChecker.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/SignatureChecker.java
@@ -620,10 +620,11 @@ public class SignatureChecker
                                 + ": Covariant return type change detected: "
                                 + toSourceForm( c.getName(), oldSignature ) + " has been changed to "
                                 + toSourceForm( c.getName(), sig ) );
-                            return true;
+                            return false;
                         }
                     }
                 }
+                return true;
             }
             return false;
         }


### PR DESCRIPTION
Treat covariant return type as an error (#77).

Not sure if this patch is correct, but it's my best guess based on the rest of the method. Please take a look.