### PR TITLE
Fix "NestMember requires ASM7"

### DIFF
--- a/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassListBuilder.java
+++ b/animal-sniffer/src/main/java/org/codehaus/mojo/animal_sniffer/ClassListBuilder.java
@@ -67,7 +67,7 @@ public class ClassListBuilder
         try
         {
             ClassReader cr = new ClassReader( image );
-            cr.accept( new ClassVisitor(Opcodes.ASM5)
+            cr.accept( new ClassVisitor(Opcodes.ASM7)
             {
                 public void visit( int version, int access, String name, String signature, String superName,
                                    String[] interfaces )


### PR DESCRIPTION
Fixes #134

I saw the above error when building a work project that uses animal-sniffer. That work project uses JDK 11 but compiles some modules for JDK 8 and uses animal-sniffer to verify correct JDK 8 api usage. I grepped the animal-sniffer code and found one remaining occurrence of ASM5. After Replacing it with ASM7, and doing a local `mvn clean install` on animal-sniffer, my work project built correctly.

Related to this PR: https://github.com/mojohaus/animal-sniffer/pull/91