### PR TITLE
Use HTTPS links in README and replace Travis badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # MojoHaus AnimalSniffer Maven Plugin
 
-This is the [animal-sniffer-maven-plugin](http://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/).
+This is the [animal-sniffer-maven-plugin](https://www.mojohaus.org/animal-sniffer/animal-sniffer-maven-plugin/).
 
 Please note this plugin is now in maintenance level as the exact same feature can be now easily achieved using the `--release` 
-flag from Javac see (http://openjdk.java.net/jeps/247)
+flag from Javac see (https://openjdk.java.net/jeps/247)
 
 [![Maven Central](https://img.shields.io/maven-central/v/org.codehaus.mojo/animal-sniffer-maven-plugin.svg?label=Maven%20Central)](https://search.maven.org/artifact/org.codehaus.mojo/animal-sniffer-maven-plugin)
-[![Build Status](https://travis-ci.org/mojohaus/animal-sniffer.svg?branch=master)](https://travis-ci.org/mojohaus/animal-sniffer)
+[![Build Status](https://github.com/mojohaus/animal-sniffer/actions/workflows/maven.yml/badge.svg)](https://github.com/mojohaus/animal-sniffer/actions/workflows/maven.yml)
 
 ## Releasing
 

--- a/src/site/apt/index.apt
+++ b/src/site/apt/index.apt
@@ -35,7 +35,7 @@ Animal Sniffer
   older JDK/API.
 
   Please note this plugin is now in maintenance level as the exact same feature can be now easily achieved using the 
-  --release flag from Javac see {{http://openjdk.java.net/jeps/247}}
+  --release flag from Javac see {{https://openjdk.java.net/jeps/247}}
 
 * Introduction
 


### PR DESCRIPTION
Replaces the Travis badge with a GitHub Actions badge.